### PR TITLE
fix WithinCircle arguments order

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/treedomtrees/commercetools-where-string-builder/issues"
   },
   "private": false,
-  "version": "1.1.1",
+  "version": "1.1.2",
   "main": "dist/index.js",
   "license": "MIT",
   "devDependencies": {

--- a/src/commerceToolsWhereStringBuilder.ts
+++ b/src/commerceToolsWhereStringBuilder.ts
@@ -217,14 +217,14 @@ export const HasNotChanged = (field: string) =>
 /**
  * Builds a WITHIN CIRCLE logical operator
  * @param field
- * @param latitude
  * @param longitude
+ * @param latitude
  * @param radius
  * @constructor
  */
 export const WithinCircle = (
   field: string,
-  latitude: number,
   longitude: number,
+  latitude: number,
   radius: number
-) => safeString`${field} within circle(${latitude}, ${longitude}, ${radius})`;
+) => safeString`${field} within circle(${longitude}, ${latitude}, ${radius})`;


### PR DESCRIPTION
Fixes issue https://github.com/treedomtrees/commercetools-where-string-builder/issues/1

```
WithinCircle: (field: string, latitude: number, longitude: number, radius: number) => string
Commmercetools has different parameters order: longitude should be first.
```

https://docs.commercetools.com/api/predicates/query
```
// Query GeoJSON field within a circle
// The two first parameters are the longitude and latitude of the circle's center.
// The third parameter is the radius of the circle in meter.
geoLocation within circle(13.37770, 52.51627, 1000)
```